### PR TITLE
Force docker to run as current user to avoid permission problems

### DIFF
--- a/drunner/servicerunner
+++ b/drunner/servicerunner
@@ -137,7 +137,7 @@ function main {
             chmod 0777 "${PROJECT_PATH}"
             
             # Copy out project files
-            docker run --rm -it -v "${PROJECT_PATH}:/tempcopy" "${IMAGENAME}" /bin/bash -c "cp -r /project/* /tempcopy/"
+            docker run --rm -it --user="$(id -u):$(id -g)" -v "${PROJECT_PATH}:/tempcopy" "${IMAGENAME}" /bin/bash -c "cp -r /project/* /tempcopy/"
             
             chownpath "${PROJECT_PATH}" "chown -R $EUID:${GROUPS[0]} /s && chmod -R 0700 /s"
 


### PR DESCRIPTION
I've added the --user flag so it runs as the current system user allowing projects to be created somewhere where world write access is always available, e.g. shared folders
