### PR TITLE
Fix /dev being overwritten when using dRunner 0.6

### DIFF
--- a/drunner/servicerunner
+++ b/drunner/servicerunner
@@ -156,7 +156,7 @@ function main {
             ;;
          
          mount)
-            bash -c "$(dockerrun mount_local)"
+            bash -c "$(dockerrun mount_local ~)"
             ;;
             
          #--- unrecognised commands


### PR DESCRIPTION
Pass in home directory when calling mount_local so it doesn't default to /dev
